### PR TITLE
Add test for multiple origins bug.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
   "bugs": {
     "url": "https://github.com/rjrodger/seneca-transport-test/issues"
   },
-  "homepage": "https://github.com/rjrodger/seneca-transport-test"
+  "homepage": "https://github.com/rjrodger/seneca-transport-test",
+  "dependencies": {
+    "async": "^1.4.2"
+  }
 }


### PR DESCRIPTION
Adds a test that fails for bugs like the cluster/invalid_origin issue in some transports:
 - https://github.com/rjrodger/seneca-rabbitmq-transport/pull/3
 - https://github.com/rjrodger/seneca-beanstalk-transport/pull/4